### PR TITLE
Fixed issue during partial sync

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -32,7 +32,6 @@ module.exports = class Todoist {
       // TODO
     }
 
-    console.log(responce.data.user.full_name);
     stateService.update(responce);
 
     // TODO


### PR DESCRIPTION
The todoist API only returns partial syncs after the first call, and partial sync doesn't return a full_name causing the code to throw an error. Removing console.log(...) fixes it.