### PR TITLE
Fix npm package name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,13 @@ The unofficial Todoist Node.js API library. Use todoist [SYNC](https://developer
 
 ## Installation
 ```
-npm install node-todoist
+npm install todoist-nodejs
 ```
 
 or
 
 ```
-yarn add node-todoist
+yarn add todoist-nodejs
 ```
 
 ## Usage


### PR DESCRIPTION
Currently listed: [node-todoist](https://www.npmjs.com/package/node-todoist)
Correct: [todoist-nodejs](https://www.npmjs.com/package/todoist-nodejs)